### PR TITLE
Updated building.md with changes required to run make on CentOS and Ubuntu

### DIFF
--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -42,4 +42,10 @@ This should work -- if you get any errors you should email me (greg@brail.org)
 
 make
 
+(NOTE: On CentOS and Ubuntu, run make with the LDFLAGS attribute set to "-L /lib64 -l pthread" if make fails;
+% make "LDFLAGS=-L /lib64 -l pthread"
+
+If this fails to work, export the attribute manually before running make; 
+% export $LDFLAGS=-L /lib64 -l pthread")
+
 *Done*: You are done and it should work now.


### PR DESCRIPTION
Exporting the LDFLAGS attribute or including such attributes as a requirement whilst running make ensures that such an operation does not fail.
