### PR TITLE
Provide information about TLS connections and more complex configuration

### DIFF
--- a/configure
+++ b/configure
@@ -3903,6 +3903,53 @@ else
   as_fn_error $? "OpenSSL library missing. Install \"openssl-devel\" or the equivalent" "$LINENO" 5
 fi
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for EVP_PKEY_id in -lcrypto" >&5
+$as_echo_n "checking for EVP_PKEY_id in -lcrypto... " >&6; }
+if ${ac_cv_lib_crypto_EVP_PKEY_id+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lcrypto  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char EVP_PKEY_id ();
+int
+main ()
+{
+return EVP_PKEY_id ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_crypto_EVP_PKEY_id=yes
+else
+  ac_cv_lib_crypto_EVP_PKEY_id=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_crypto_EVP_PKEY_id" >&5
+$as_echo "$ac_cv_lib_crypto_EVP_PKEY_id" >&6; }
+if test "x$ac_cv_lib_crypto_EVP_PKEY_id" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIBCRYPTO 1
+_ACEOF
+
+  LIBS="-lcrypto $LIBS"
+
+else
+  as_fn_error $? "OpenSSL library missing. Install \"openssl-devel\" or the equivalent" "$LINENO" 5
+fi
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for apr_initialize in -lapr-1" >&5
 $as_echo_n "checking for apr_initialize in -lapr-1... " >&6; }
 if ${ac_cv_lib_apr_1_apr_initialize+:} false; then :
@@ -4028,6 +4075,9 @@ fi
 APR_LOC=$APR_LOC
 
 
+# Homebrew on OS X puts the OpenSSL headers in a variety of different places,
+# and this is harder if you install Homebrew in a non-standard location.
+# This finds it.
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for /usr/include/openssl/ssl.h" >&5
 $as_echo_n "checking for /usr/include/openssl/ssl.h... " >&6; }
 if ${ac_cv_file__usr_include_openssl_ssl_h+:} false; then :

--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,8 @@ AC_SEARCH_LIBS([CRYPTO_num_locks], crypto)
 AC_SEARCH_LIBS([pthread_create], pthread)
 AC_CHECK_LIB([ssl], [SSL_read], [],
              [AC_MSG_ERROR([OpenSSL library missing. Install "openssl-devel" or the equivalent])])
+AC_CHECK_LIB([crypto], [EVP_PKEY_id], [],
+             [AC_MSG_ERROR([OpenSSL library missing. Install "openssl-devel" or the equivalent])])
 AC_CHECK_LIB([apr-1], [apr_initialize], [],
              [AC_MSG_ERROR([APR library missing. Install "apr-devel" or the equivalent])])
 AC_CHECK_LIB([aprutil-1], [apr_uri_parse], [],

--- a/src/apib.h
+++ b/src/apib.h
@@ -42,6 +42,7 @@ typedef struct {
   unsigned int    sendDataSize;
   SSL_CTX*        sslCtx;
   char*           tlsConfig;
+  char***         sslSettings;
   char**          headers;
   pq_Queue*       delayQueue;
   unsigned int    thinkTime;

--- a/src/apib.h
+++ b/src/apib.h
@@ -41,6 +41,7 @@ typedef struct {
   char*           sslCipher;
   unsigned int    sendDataSize;
   SSL_CTX*        sslCtx;
+  char*           tlsConfig;
   char**          headers;
   pq_Queue*       delayQueue;
   unsigned int    thinkTime;

--- a/src/apib_iothread.c
+++ b/src/apib_iothread.c
@@ -194,8 +194,6 @@ panic:
   SETSTATE(conn, STATE_PANIC);
 }
 
-
-
 static int setupConnection(ConnectionInfo* conn)
 {
   apr_status_t s;
@@ -239,6 +237,10 @@ static int handshakeSsl(ConnectionInfo* conn)
       return STATUS_CONTINUE;
     }
     assert(FALSE);
+  }
+
+  if (!conn->ioArgs->tlsConfig) {
+    conn->ioArgs->tlsConfig = strdup(SSL_get_cipher_name(conn->ssl));
   }
 
   SETSTATE(conn, STATE_SEND_READY);

--- a/src/apib_main.c
+++ b/src/apib_main.c
@@ -256,6 +256,7 @@ static int createSslContext(IOArgs* args, int isFirst)
     SSL_library_init();
     initSSLLocks();
   }
+  args->tlsConfig = NULL;
   args->sslCtx = SSL_CTX_new(SSLv23_client_method());
   SSL_CTX_set_options(args->sslCtx, SSL_OP_ALL);
   SSL_CTX_set_mode(args->sslCtx, SSL_MODE_ENABLE_PARTIAL_WRITE);
@@ -635,6 +636,7 @@ int main(int ac, char const* const* av)
     return 0;
   }
 
+  CompareTLSConfigs(ioArgs, NumThreads);
   ConsolidateLatencies(ioArgs, NumThreads);
   PrintResults(stdout);
   EndReporting();


### PR DESCRIPTION
In the end report, also provide some basic info about the negotiated connection, like protocol version, cipher suite and the ephemeral key used (if any).

Additionally, allow for providing arbitrary settings to OpenSSL using the SSL_CONF_cmd interface (for setting the TLS1.3 ciphers, key exchange groups or signature algorithms)