### PR TITLE
Fix errors in output reporting

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -37,7 +37,6 @@ cc_library(
         "apib_cpu.h",
         "apib_lines.h",
         "apib_rand.h",
-        "apib_reporting.h",
         "apib_time.h",
         "apib_url.h",
         "apib_util.h",
@@ -65,6 +64,7 @@ cc_library(
         "apib_commandqueue.h",
         "apib_iothread.h",
         "apib_oauth.h",
+        "apib_reporting.h",
     ],
     linkopts = [
         "-lpthread",
@@ -72,6 +72,7 @@ cc_library(
     deps = [
         ":common",
         "//third_party:base64",
+        "@absl//absl/strings:str_format",
         "@boringssl//:crypto",
         "@boringssl//:ssl",
         "@httpparser",

--- a/src/apib_cpu_generic.cc
+++ b/src/apib_cpu_generic.cc
@@ -30,8 +30,8 @@ void cpu_GetUsage(CPUUsage* usage) {
   usage->timestamp = 0;
 }
 
-double cpu_GetInterval(CPUUsage* usage) { return -1.0; }
+double cpu_GetInterval(CPUUsage* usage) { return 0.0; }
 
-double cpu_GetMemoryUsage() { return -1.0; }
+double cpu_GetMemoryUsage() { return 0.0; }
 
 }  // namespace apib

--- a/src/apib_main.cc
+++ b/src/apib_main.cc
@@ -257,7 +257,9 @@ static void waitAndReport(const apib::ThreadList &threads, int duration,
     }
 
     sleep(toSleep);
-    if (!ShortOutput) {
+    if (ShortOutput) {
+      apib::SampleCPU();
+    } else {
       ReportInterval(std::cout, threads, duration, warmup);
     }
     durationLeft -= toSleep;

--- a/src/apib_reporting.cc
+++ b/src/apib_reporting.cc
@@ -409,75 +409,61 @@ BenchmarkResults ReportResults() {
 void PrintFullResults(std::ostream& out) {
   const BenchmarkResults r = ReportResults();
 
-  out << StrFormat("Duration:             %.3f seconds", r.elapsedTime) << endl;
-  out << StrFormat("Attempted requests:   %i", r.completedRequests) << endl;
-  out << StrFormat("Successful requests:  %i", r.successfulRequests) << endl;
-  out << StrFormat("Non-200 results:      %i", r.unsuccessfulRequests) << endl;
-  out << StrFormat("Connections opened:   %i", r.connectionsOpened) << endl;
-  out << StrFormat("Socket errors:        %i", r.socketErrors) << endl;
-  out << endl;
-  out << StrFormat("Throughput:           %.3f requests/second",
-                   r.averageThroughput)
-      << endl;
-  out << StrFormat("Average latency:      %.3f milliseconds", r.averageLatency)
-      << endl;
-  out << StrFormat("Minimum latency:      %.3f milliseconds", r.latencies[0])
-      << endl;
-  out << StrFormat("Maximum latency:      %.3f milliseconds", r.latencies[100])
-      << endl;
-  out << StrFormat("Latency std. dev:     %.3f milliseconds", r.latencyStdDev)
-      << endl;
-  out << StrFormat("50%% latency:          %.3f milliseconds", r.latencies[50])
-      << endl;
-  out << StrFormat("90%% latency:          %.3f milliseconds", r.latencies[90])
-      << endl;
-  out << StrFormat("98%% latency:          %.3f milliseconds", r.latencies[98])
-      << endl;
-  out << StrFormat("99%% latency:          %.3f milliseconds", r.latencies[99])
-      << endl;
-  out << endl;
+  out << StrFormat("Duration:             %.3f seconds\n", r.elapsedTime);
+  out << StrFormat("Attempted requests:   %i\n", r.completedRequests);
+  out << StrFormat("Successful requests:  %i\n", r.successfulRequests);
+  out << StrFormat("Non-200 results:      %i\n", r.unsuccessfulRequests);
+  out << StrFormat("Connections opened:   %i\n", r.connectionsOpened);
+  out << StrFormat("Socket errors:        %i\n", r.socketErrors);
+  out << '\n';
+  out << StrFormat("Throughput:           %.3f requests/second\n",
+                   r.averageThroughput);
+  out << StrFormat("Average latency:      %.3f milliseconds\n",
+                   r.averageLatency);
+  out << StrFormat("Minimum latency:      %.3f milliseconds\n", r.latencies[0]);
+  out << StrFormat("Maximum latency:      %.3f milliseconds\n",
+                   r.latencies[100]);
+  out << StrFormat("Latency std. dev:     %.3f milliseconds\n",
+                   r.latencyStdDev);
+  out << StrFormat("50%% latency:          %.3f milliseconds\n",
+                   r.latencies[50]);
+  out << StrFormat("90%% latency:          %.3f milliseconds\n",
+                   r.latencies[90]);
+  out << StrFormat("98%% latency:          %.3f milliseconds\n",
+                   r.latencies[98]);
+  out << StrFormat("99%% latency:          %.3f milliseconds\n",
+                   r.latencies[99]);
+  out << '\n';
   if (!clientSamples.empty()) {
-    out << StrFormat("Client CPU average:    %.0f%%",
-                     getAverageCpu(clientSamples) * 100.0)
-        << endl;
-    out << StrFormat("Client CPU max:        %.0f%%",
-                     getMaxCpu(clientSamples) * 100.0)
-        << endl;
+    out << StrFormat("Client CPU average:   %.0f%%\n",
+                     getAverageCpu(clientSamples) * 100.0);
+    out << StrFormat("Client CPU max:       %.0f%%\n",
+                     getMaxCpu(clientSamples) * 100.0);
   }
-  out << StrFormat("Client memory usage:   %.0f%%", clientMem * 100.0) << endl;
+  out << StrFormat("Client memory usage:  %.0f%%\n", clientMem * 100.0);
   if (!remoteSamples.empty()) {
-    out << StrFormat("Remote CPU average:    %.0f%%",
-                     getAverageCpu(remoteSamples) * 100.0)
-        << endl;
-    out << StrFormat("Remote CPU max:        %.0f%%",
-                     getMaxCpu(remoteSamples) * 100.0)
-        << endl;
-    out << StrFormat("Remote memory usage:   %.0f%%", remoteMem * 100.0)
-        << endl;
+    out << StrFormat("Remote CPU average:   %.0f%%\n",
+                     getAverageCpu(remoteSamples) * 100.0);
+    out << StrFormat("Remote CPU max:       %.0f%%\n",
+                     getMaxCpu(remoteSamples) * 100.0);
+    out << StrFormat("Remote memory usage:  %.0f%%\n", remoteMem * 100.0);
   }
   if (!remote2Samples.empty()) {
-    out << StrFormat("Remote 2 CPU average:    %.0f%%",
-                     getAverageCpu(remote2Samples) * 100.0)
-        << endl;
-    out << StrFormat("Remote 2 CPU max:        %.0f%%",
-                     getMaxCpu(remote2Samples) * 100.0)
-        << endl;
-    out << StrFormat("Remote 2 memory usage:   %.0f%%", remote2Mem * 100.0)
-        << endl;
+    out << StrFormat("Remote 2 CPU average:   %.0f%%\n",
+                     getAverageCpu(remote2Samples) * 100.0);
+    out << StrFormat("Remote 2 CPU max:       %.0f%%\n",
+                     getMaxCpu(remote2Samples) * 100.0);
+    out << StrFormat("Remote 2 memory usage:  %.0f%%\n", remote2Mem * 100.0);
   }
-  out << endl;
-  out << StrFormat("Total bytes sent:      %.2f megabytes",
-                   r.totalBytesSent / 1048576.0)
-      << endl;
-  out << StrFormat("Total bytes received:  %.2f megabytes",
-                   r.totalBytesReceived / 1048576.0)
-      << endl;
-  out << StrFormat("Send bandwidth:        %.2f megabits / second",
-                   r.averageSendBandwidth)
-      << endl;
-  out << StrFormat("Receive bandwidth:     %.2f megabits / second",
-                   r.averageReceiveBandwidth)
-      << endl;
+  out << '\n';
+  out << StrFormat("Total bytes sent:     %.2f megabytes\n",
+                   r.totalBytesSent / 1048576.0);
+  out << StrFormat("Total bytes received: %.2f megabytes\n",
+                   r.totalBytesReceived / 1048576.0);
+  out << StrFormat("Send bandwidth:       %.2f megabits / second\n",
+                   r.averageSendBandwidth);
+  out << StrFormat("Receive bandwidth:    %.2f megabits / second\n",
+                   r.averageReceiveBandwidth);
 }
 
 void PrintShortResults(std::ostream& out, const std::string& runName,
@@ -486,19 +472,17 @@ void PrintShortResults(std::ostream& out, const std::string& runName,
 
   // See "PrintReportingHeader for column names
   out << StrFormat(
-             "%s,%.3f,%.3f,%i,%i,%.3f,%i,%i,%i,%i,%.3f,%.3f,%.3f,%.3f,%.3f,%."
-             "3f,%.3f,%.0f,%.0f,%.0f,%.0f,%.0f,%.0f,%.2f,%.2f",
-             runName, r.averageThroughput, r.averageLatency, numThreads,
-             connections, r.elapsedTime, r.completedRequests,
-             r.successfulRequests, r.socketErrors, r.connectionsOpened,
-             r.latencies[0], r.latencies[100], r.latencies[50], r.latencies[90],
-             r.latencies[98], r.latencies[99], r.latencyStdDev,
-             getAverageCpu(clientSamples) * 100.0,
-             getAverageCpu(remoteSamples) * 100.0,
-             getAverageCpu(remote2Samples) * 100.0, clientMem * 100.0,
-             remoteMem * 100.0, remote2Mem * 100.0, r.averageSendBandwidth,
-             r.averageReceiveBandwidth)
-      << endl;
+      "%s,%.3f,%.3f,%i,%i,%.3f,%i,%i,%i,%i,%.3f,%.3f,%.3f,%.3f,%.3f,%."
+      "3f,%.3f,%.0f,%.0f,%.0f,%.0f,%.0f,%.0f,%.2f,%.2f\n",
+      runName, r.averageThroughput, r.averageLatency, numThreads, connections,
+      r.elapsedTime, r.completedRequests, r.successfulRequests, r.socketErrors,
+      r.connectionsOpened, r.latencies[0], r.latencies[100], r.latencies[50],
+      r.latencies[90], r.latencies[98], r.latencies[99], r.latencyStdDev,
+      getAverageCpu(clientSamples) * 100.0,
+      getAverageCpu(remoteSamples) * 100.0,
+      getAverageCpu(remote2Samples) * 100.0, clientMem * 100.0,
+      remoteMem * 100.0, remote2Mem * 100.0, r.averageSendBandwidth,
+      r.averageReceiveBandwidth);
 }
 
 void PrintReportingHeader(std::ostream& out) {
@@ -508,8 +492,7 @@ void PrintReportingHeader(std::ostream& out) {
          "98% Latency,99% Latency,Latency Std Dev,Avg Client CPU,"
          "Avg Server CPU,Avg Server 2 CPU,"
          "Client Mem Usage,Server Mem,Server 2 Mem,"
-         "Avg. Send Bandwidth,Avg. Recv. Bandwidth"
-      << endl;
+         "Avg. Send Bandwidth,Avg. Recv. Bandwidth\n";
 }
 
 void EndReporting() {

--- a/src/apib_reporting.cc
+++ b/src/apib_reporting.cc
@@ -226,8 +226,8 @@ void RecordStart(bool startReporting, const ThreadList& threads) {
 }
 
 void RecordStop(const ThreadList& threads) {
+  SampleCPU();
   clientMem = cpu_GetMemoryUsage();
-
   if (remoteCpuSocket != 0) {
     remoteMem = getRemoteStat(kMemCmd, &remoteCpuSocket);
   }
@@ -273,6 +273,19 @@ BenchmarkIntervalResults ReportIntervalResults(const ThreadList& threads) {
   r.averageThroughput = (double)r.successfulRequests / r.intervalTime;
   intervalStartTime = now;
   return r;
+}
+
+void SampleCPU() {
+  if (remoteCpuSocket != 0) {
+    const double remoteCpu = getRemoteStat(kCPUCmd, &remoteCpuSocket);
+    remoteSamples.push_back(remoteCpu);
+  }
+  if (remote2CpuSocket != 0) {
+    const double remote2Cpu = getRemoteStat(kCPUCmd, &remote2CpuSocket);
+    remote2Samples.push_back(remote2Cpu);
+  }
+  const double cpu = cpu_GetInterval(&cpuUsage);
+  clientSamples.push_back(cpu);
 }
 
 void ReportInterval(std::ostream& out, const ThreadList& threads,

--- a/src/apib_reporting.h
+++ b/src/apib_reporting.h
@@ -103,6 +103,10 @@ extern void PrintFullResults(std::ostream& out);
 // Call ReportIntervalResults and print to a file
 extern void ReportInterval(std::ostream& out, const ThreadList& threads,
                            int totalDuration, bool warmup);
+// If ReportInterval is not being called, call this instead to ensure
+// that the CPU samples are happening regularly so
+// that we get a good average.
+extern void SampleCPU();
 // Print a CSV header for the "short" reporting format
 extern void PrintReportingHeader(std::ostream& out);
 


### PR DESCRIPTION
* If CPU reporting wasn't available, results were reported as "NaN" in short output
* CPU sampling wasn't being done at all in short output
* Missing a column in short output compared to the CSV header
* Use absl::StrFormat for less crufty code when formatting strings.
