### PR TITLE
Replace std::regex use.

### DIFF
--- a/apib/socket.h
+++ b/apib/socket.h
@@ -33,7 +33,7 @@ typedef enum { OK, NEED_READ, NEED_WRITE, FEOF } IOStatus;
  */
 class Socket {
  public:
-  Socket() :fd_(0) {}
+  Socket() : fd_(0) {}
   Socket(const Socket&) = delete;
   Socket& operator=(const Socket&) = delete;
   virtual ~Socket();


### PR DESCRIPTION
A regex that worked in some places was failing on Centos.
Turns out that regex was overkill in that place.